### PR TITLE
Add Qt Quick classes to CMake Configuration, Add fix for addIgnoreObject in child windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,21 @@ endif()
 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Gui REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Gui REQUIRED)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Quick)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Quick)
 
 set(SOURCES
     framelesshelper_global.h
     framelesswindowsmanager.h
     framelesswindowsmanager.cpp
 )
+
+if(TARGET Qt${QT_VERSION_MAJOR}::Quick)
+    list(APPEND SOURCES
+        framelessquickhelper.h
+        framelessquickhelper.cpp
+    )
+endif()
 
 if(WIN32)
     list(APPEND SOURCES
@@ -76,6 +85,11 @@ endif()
 target_link_libraries(${PROJECT_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::GuiPrivate
 )
+if(TARGET Qt${QT_VERSION_MAJOR}::Quick)
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+        Qt${QT_VERSION_MAJOR}::Quick
+    )
+endif()
 target_include_directories(${PROJECT_NAME} PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>"
 )

--- a/winnativeeventfilter.cpp
+++ b/winnativeeventfilter.cpp
@@ -873,6 +873,9 @@ bool WinNativeEventFilter::nativeEventFilter(const QByteArray &eventType,
                     QPointF point = {obj->property("x").toReal(), obj->property("y").toReal()};
                     for (QObject *parent = obj->parent(); parent; parent = parent->parent()) {
                         point += {parent->property("x").toReal(), parent->property("y").toReal()};
+                        if (parent->isWindowType()) {
+                            break;
+                        }
                     }
                     return point;
                 };


### PR DESCRIPTION
This pull request covers two separate issues:

* Adding the Qt Quick helper class to CMakeLists.txt
* Fixing #45 

Explanation of #45 fix:

```cpp
  for (QObject *parent = obj->parent(); parent; parent = parent->parent()) {
      point += {parent->property("x").toReal(), parent->property("y").toReal()};
      if(parent->isWindowType())
          break;
```

This loop should only map to the ignore object's parent _window_. If this window happens to be a child window of the main application, the coordinates are incorrect because the loop was adding coordinates from the main application parent window.