### PR TITLE
improve titlebar move behavor

### DIFF
--- a/framelesshelper.cpp
+++ b/framelesshelper.cpp
@@ -131,6 +131,16 @@ bool FramelessHelper::eventFilter(QObject *object, QEvent *event)
                 && (localMousePosition.x() < (windowWidth - resizeBorderWidth))
                 && !hitTestVisible;
     }
+
+    // Determine if the mouse click occurred in the title bar
+    static bool titlebarClicked = false;
+    if (type == QEvent::MouseButtonPress) {
+        if (isInTitlebarArea)
+            titlebarClicked = true;
+        else
+            titlebarClicked = false;
+    }
+
     if (type == QEvent::MouseButtonDblClick) {
         if (mouseEvent->button() != Qt::MouseButton::LeftButton) {
             return false;
@@ -164,7 +174,7 @@ bool FramelessHelper::eventFilter(QObject *object, QEvent *event)
             }
         }
 
-        if (mouseEvent->buttons() & Qt::LeftButton) {
+        if ((mouseEvent->buttons() & Qt::LeftButton) && titlebarClicked) {
             if (edges == Qt::Edges{}) {
                 if (isInTitlebarArea) {
                     if (!window->startSystemMove()) {


### PR DESCRIPTION
在 #73 的 PR 中为了解决 #72 问题，决定使用 MouseMove 事件来决定标题栏移动的行为。但 #73 的实现方式导致标题栏的行为不够原生，而此 PR 解决为了解决这个问题。

一次鼠标拖动标题栏的动作可以分解成：MouseButtonPress > MouseMove > MouseButtonRelease ，因此我创建了一个静态变量 titlebarClicked 来判断并记录 MouseButtonPress 是否发生在标题栏区域，只有当 titlebarClicked 而且 MouseMove 并同时按住左键时，才会调用 startSystemMove 。因此，解决了 #73 的瑕疵。