### PR TITLE
关闭“将警告视为错误”的配置项

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -94,7 +94,7 @@ if(MSVC)
         _WIN32_IE=${_WIN32_WINNT_WIN10} NTDDI_VERSION=${NTDDI_WIN10_CO}
     )
     target_compile_options(${SUB_PROJ_NAME} PRIVATE
-        /utf-8 /W4 /WX
+        /utf-8 /W4 /WX-
     )
 else()
     target_compile_options(${SUB_PROJ_NAME} PRIVATE


### PR DESCRIPTION
不然VS2019下编译不能通过