### PR TITLE
Support hit testing when using QQuickRenderControls

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,4 +8,5 @@ endif()
 
 if(TARGET Qt${QT_VERSION_MAJOR}::Quick)
     add_subdirectory(quick)
+    add_subdirectory(rendercontrol_opengl)
 endif()

--- a/examples/examples.pro
+++ b/examples/examples.pro
@@ -1,4 +1,4 @@
 TEMPLATE = subdirs
 CONFIG -= ordered
 qtHaveModule(widgets): SUBDIRS += widget mainwindow
-qtHaveModule(quick): SUBDIRS += quick
+qtHaveModule(quick): SUBDIRS += quick rendercontrol_opengl

--- a/examples/rendercontrol_opengl/CMakeLists.txt
+++ b/examples/rendercontrol_opengl/CMakeLists.txt
@@ -13,7 +13,7 @@ set(SOURCES
     window_singlethreaded.cpp
 )
 
-qt_add_executable(rendercontrol_openglexample WIN32 ${SOURCES})
+add_executable(rendercontrol_openglexample WIN32 ${SOURCES})
 
 target_link_libraries(rendercontrol_openglexample PRIVATE
     Qt${QT_VERSION_MAJOR}::Core

--- a/examples/rendercontrol_opengl/CMakeLists.txt
+++ b/examples/rendercontrol_opengl/CMakeLists.txt
@@ -1,0 +1,33 @@
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui OpenGL Qml Quick)
+
+set(SOURCES
+    rendercontrol.qrc
+    main.cpp
+    window_singlethreaded.cpp
+)
+
+qt_add_executable(rendercontrol_openglexample WIN32 ${SOURCES})
+
+target_link_libraries(rendercontrol_openglexample PRIVATE
+    Qt${QT_VERSION_MAJOR}::Core
+	Qt${QT_VERSION_MAJOR}::Gui
+	Qt${QT_VERSION_MAJOR}::OpenGL
+	Qt${QT_VERSION_MAJOR}::Quick
+	Qt${QT_VERSION_MAJOR}::Qml
+    Qt${QT_VERSION_MAJOR}::QuickControls2
+    wangwenx190::FramelessHelper
+)
+
+target_compile_definitions(Quick PRIVATE
+    QT_NO_CAST_FROM_ASCII
+    QT_NO_CAST_TO_ASCII
+    QT_NO_KEYWORDS
+    QT_DEPRECATED_WARNINGS
+    QT_DISABLE_DEPRECATED_BEFORE=0x060200
+)

--- a/examples/rendercontrol_opengl/CMakeLists.txt
+++ b/examples/rendercontrol_opengl/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui OpenGL Qml Quick)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui OpenGL Qml Quick QuickControls2)
 
 set(SOURCES
     rendercontrol.qrc

--- a/examples/rendercontrol_opengl/CMakeLists.txt
+++ b/examples/rendercontrol_opengl/CMakeLists.txt
@@ -17,10 +17,10 @@ qt_add_executable(rendercontrol_openglexample WIN32 ${SOURCES})
 
 target_link_libraries(rendercontrol_openglexample PRIVATE
     Qt${QT_VERSION_MAJOR}::Core
-	Qt${QT_VERSION_MAJOR}::Gui
-	Qt${QT_VERSION_MAJOR}::OpenGL
-	Qt${QT_VERSION_MAJOR}::Quick
-	Qt${QT_VERSION_MAJOR}::Qml
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::OpenGL
+    Qt${QT_VERSION_MAJOR}::Quick
+    Qt${QT_VERSION_MAJOR}::Qml
     Qt${QT_VERSION_MAJOR}::QuickControls2
     wangwenx190::FramelessHelper
 )

--- a/examples/rendercontrol_opengl/CMakeLists.txt
+++ b/examples/rendercontrol_opengl/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_AUTORCC ON)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui OpenGL Qml Quick QuickControls2)
 
 set(SOURCES
+    ../images.qrc
     rendercontrol.qrc
     main.cpp
     window_singlethreaded.cpp

--- a/examples/rendercontrol_opengl/main.cpp
+++ b/examples/rendercontrol_opengl/main.cpp
@@ -51,6 +51,7 @@
 #include <QGuiApplication>
 #include <QQuickWindow>
 #include "window_singlethreaded.h"
+#include <QtQuickControls2/qquickstyle.h>
 
 int main(int argc, char *argv[])
 {
@@ -64,6 +65,12 @@ int main(int argc, char *argv[])
 #endif
 
     QGuiApplication application(argc, argv);
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QQuickStyle::setStyle(QStringLiteral("Basic"));
+#else
+    QQuickStyle::setStyle(QStringLiteral("Default"));
+#endif
 
     // only functional when Qt Quick is also using OpenGL
     QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);

--- a/examples/rendercontrol_opengl/main.cpp
+++ b/examples/rendercontrol_opengl/main.cpp
@@ -1,0 +1,76 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the examples of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:BSD$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** BSD License Usage
+** Alternatively, you may use this file under the terms of the BSD license
+** as follows:
+**
+** "Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are
+** met:
+**   * Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**   * Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in
+**     the documentation and/or other materials provided with the
+**     distribution.
+**   * Neither the name of The Qt Company Ltd nor the names of its
+**     contributors may be used to endorse or promote products derived
+**     from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include <QGuiApplication>
+#include <QQuickWindow>
+#include "window_singlethreaded.h"
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::Round);
+#endif
+
+    QGuiApplication application(argc, argv);
+
+    // only functional when Qt Quick is also using OpenGL
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
+
+    WindowSingleThreaded window;
+    window.resize(1200, 720);
+    window.show();
+
+    return application.exec();
+}

--- a/examples/rendercontrol_opengl/main.cpp
+++ b/examples/rendercontrol_opengl/main.cpp
@@ -72,8 +72,10 @@ int main(int argc, char *argv[])
     QQuickStyle::setStyle(QStringLiteral("Default"));
 #endif
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     // only functional when Qt Quick is also using OpenGL
     QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
+#endif
 
     WindowSingleThreaded window;
     window.resize(1200, 720);

--- a/examples/rendercontrol_opengl/qml/CloseButton.qml
+++ b/examples/rendercontrol_opengl/qml/CloseButton.qml
@@ -1,0 +1,48 @@
+/*
+ * MIT License
+ *
+ * Copyright (C) 2021 by wangwenx190 (Yuhang Zhao)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+
+Button {
+    id: button
+
+    implicitWidth: 45
+    implicitHeight: 30
+
+    ToolTip.visible: hovered && !down
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+    ToolTip.text: qsTr("Close")
+
+    contentItem: Image {
+        anchors.fill: parent
+        source: button.down
+                || button.hovered ? "qrc:/images/button_close_white.svg" : "qrc:/images/button_close_black.svg"
+    }
+
+    background: Rectangle {
+        visible: button.down || button.hovered
+        color: button.down ? "#8c0a15" : (button.hovered ? "#e81123" : "transparent")
+    }
+}

--- a/examples/rendercontrol_opengl/qml/MaximizeButton.qml
+++ b/examples/rendercontrol_opengl/qml/MaximizeButton.qml
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (C) 2021 by wangwenx190 (Yuhang Zhao)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+
+Button {
+    id: button
+
+    implicitWidth: 45
+    implicitHeight: 30
+
+    property bool maximized: false
+
+    ToolTip.visible: hovered && !down
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+    ToolTip.text: maximized ? qsTr("Restore") : qsTr("Maximize")
+
+    contentItem: Image {
+        anchors.fill: parent
+        source: maximized ? "qrc:/images/button_restore_black.svg" : "qrc:/images/button_maximize_black.svg"
+    }
+
+    background: Rectangle {
+        visible: button.down || button.hovered
+        color: button.down ? "#808080" : (button.hovered ? "#c7c7c7" : "transparent")
+    }
+}

--- a/examples/rendercontrol_opengl/qml/MinimizeButton.qml
+++ b/examples/rendercontrol_opengl/qml/MinimizeButton.qml
@@ -1,0 +1,47 @@
+/*
+ * MIT License
+ *
+ * Copyright (C) 2021 by wangwenx190 (Yuhang Zhao)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+
+Button {
+    id: button
+
+    implicitWidth: 45
+    implicitHeight: 30
+
+    ToolTip.visible: hovered && !down
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+    ToolTip.text: qsTr("Minimize")
+
+    contentItem: Image {
+        anchors.fill: parent
+        source: "qrc:/images/button_minimize_black.svg"
+    }
+
+    background: Rectangle {
+        visible: button.down || button.hovered
+        color: button.down ? "#808080" : (button.hovered ? "#c7c7c7" : "transparent")
+    }
+}

--- a/examples/rendercontrol_opengl/qml/main.qml
+++ b/examples/rendercontrol_opengl/qml/main.qml
@@ -1,0 +1,111 @@
+/*
+ * MIT License
+ *
+ * Copyright (C) 2021 by wangwenx190 (Yuhang Zhao)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+
+Rectangle {
+    id: root
+    property real _flh_margin: ((window.visibility === Window.Maximized) || (window.visibility === Window.FullScreen)) ? 0 : 1
+    property var _win_prev_state: null
+
+    color: "#f0f0f0"
+
+    Timer {
+        id: timer
+        interval: 500
+        running: true
+        repeat: true
+        onTriggered: timeLabel.text = Qt.formatTime(new Date(), "hh:mm:ss")
+    }
+
+    Label {
+        id: timeLabel
+        anchors.centerIn: parent
+        font {
+            pointSize: 70
+            bold: true
+        }
+    }
+
+    Rectangle {
+        id: titleBar
+        height: window.titleBarHeight
+        color: "white"
+        anchors {
+            top: parent.top
+            topMargin: window._flh_margin
+            left: parent.left
+            leftMargin: window._flh_margin
+            right: parent.right
+            rightMargin: window._flh_margin
+        }
+
+        Text {
+            id: titleBarText
+            text: window.title
+            font.pointSize: 13
+            color: window.active ? "black" : "gray"
+            anchors.left: parent.left
+            anchors.leftMargin: 15
+            anchors.verticalCenter: parent.verticalCenter
+        }
+
+        Row {
+            anchors.top: parent.top
+            anchors.right: parent.right
+
+            MinimizeButton {
+                id: minimizeButton
+                onClicked: {
+                    console.log("minimizeButton clicked")
+                    window.showMinimized()
+                }
+                Component.onCompleted: window.setHitTestVisible(minimizeButton, true)
+            }
+
+            MaximizeButton {
+                id: maximizeButton
+                maximized: ((window.visibility === Window.Maximized) || (window.visibility === Window.FullScreen))
+                onClicked: {
+                    if (maximized) {
+                        window.showNormal()
+                    } else {
+                        window.showMaximized()
+                    }
+                }
+                Component.onCompleted: window.setHitTestVisible(maximizeButton, true)
+            }
+
+            CloseButton {
+                id: closeButton
+                onClicked: window.close()
+                Component.onCompleted: window.setHitTestVisible(closeButton, true)
+            }
+        }
+    }
+
+    Keys.onPressed: keyDown = true
+    Keys.onReleased: keyDown = false
+}

--- a/examples/rendercontrol_opengl/rendercontrol.qrc
+++ b/examples/rendercontrol_opengl/rendercontrol.qrc
@@ -1,0 +1,8 @@
+<RCC>
+    <qresource prefix="/rendercontrol">
+        <file>qml/CloseButton.qml</file>
+        <file>qml/main.qml</file>
+        <file>qml/MaximizeButton.qml</file>
+        <file>qml/MinimizeButton.qml</file>
+    </qresource>
+</RCC>

--- a/examples/rendercontrol_opengl/rendercontrol_opengl.pro
+++ b/examples/rendercontrol_opengl/rendercontrol_opengl.pro
@@ -1,0 +1,7 @@
+TARGET = RenderControl
+TEMPLATE = app
+QT += quick qml opengl
+SOURCES += main.cpp window_singlethreaded.cpp
+HEADERS += window_singlethreaded.h
+RESOURCES += rendercontrol.qrc
+include($$PWD/../common.pri)

--- a/examples/rendercontrol_opengl/rendercontrol_opengl.pro
+++ b/examples/rendercontrol_opengl/rendercontrol_opengl.pro
@@ -1,6 +1,6 @@
 TARGET = RenderControl
 TEMPLATE = app
-QT += quick qml opengl
+QT += quick qml opengl quickcontrols2
 SOURCES += main.cpp window_singlethreaded.cpp
 HEADERS += window_singlethreaded.h
 RESOURCES += rendercontrol.qrc

--- a/examples/rendercontrol_opengl/window_singlethreaded.cpp
+++ b/examples/rendercontrol_opengl/window_singlethreaded.cpp
@@ -1,0 +1,486 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the examples of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:BSD$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** BSD License Usage
+** Alternatively, you may use this file under the terms of the BSD license
+** as follows:
+**
+** "Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are
+** met:
+**   * Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**   * Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in
+**     the documentation and/or other materials provided with the
+**     distribution.
+**   * Neither the name of The Qt Company Ltd nor the names of its
+**     contributors may be used to endorse or promote products derived
+**     from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "window_singlethreaded.h"
+
+#include "../../framelesswindowsmanager.h"
+
+#include <QOpenGLContext>
+#include <QOpenGLFunctions>
+#include <QOpenGLFramebufferObject>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLVertexArrayObject>
+#include <QOpenGLBuffer>
+#include <QOffscreenSurface>
+#include <QScreen>
+#include <QQmlEngine>
+#include <QQmlComponent>
+#include <QQmlContext>
+#include <QQuickItem>
+#include <QQuickWindow>
+#include <QQuickRenderControl>
+#include <QCoreApplication>
+#include <QQuickRenderTarget>
+#include <QQuickGraphicsDevice>
+
+#define DEPTH_BUFFER_SIZE 16
+#define STENCIL_BUFFER_SIZE 16
+
+class RenderControlImp : public QQuickRenderControl
+{
+public:
+    RenderControlImp(QWindow *displayedWindow) : m_displayedWindow(displayedWindow) { }
+    QWindow *renderWindow(QPoint *offset) override { return m_displayedWindow; }
+
+private:
+    QWindow *m_displayedWindow;
+};
+
+WindowSingleThreaded::WindowSingleThreaded()
+{
+    this->setSurfaceType(QSurface::OpenGLSurface);
+
+    QSurfaceFormat surfaceFormat;
+    // Qt Quick may need a depth and stencil buffer. Always make sure these are available.
+    surfaceFormat.setDepthBufferSize(DEPTH_BUFFER_SIZE);
+    surfaceFormat.setStencilBufferSize(STENCIL_BUFFER_SIZE);
+    this->setFormat(surfaceFormat);
+
+    m_glContext = new QOpenGLContext;
+    m_glContext->setFormat(surfaceFormat);
+    m_glContext->create();
+
+    m_offscreenSurface = new QOffscreenSurface;
+    // Pass m_context->format(), not format. Format does not specify and color buffer
+    // sizes, while the context, that has just been created, reports a format that has
+    // these values filled in. Pass this to the offscreen surface to make sure it will be
+    // compatible with the context's configuration.
+    m_offscreenSurface->setFormat(m_glContext->format());
+    m_offscreenSurface->create();
+
+    m_renderControl = new RenderControlImp(this);
+
+    // Create a QQuickWindow that is associated with out render control. Note that this
+    // window never gets created or shown, meaning that it will never get an underlying
+    // native (platform) window.
+    m_quickWindow = new QQuickWindow(m_renderControl);
+
+    // Create a QML engine.
+    m_qmlEngine = new QQmlEngine;
+    if (!m_qmlEngine->incubationController())
+        m_qmlEngine->setIncubationController(m_quickWindow->incubationController());
+
+    m_qmlEngine->rootContext()->setContextProperty(QStringLiteral("window"), this);
+
+    // When Quick says there is a need to render, we will not render immediately. Instead,
+    // a timer with a small interval is used to get better performance.
+    m_updateTimer.setSingleShot(true);
+    m_updateTimer.setInterval(5);
+    connect(&m_updateTimer, &QTimer::timeout, this, &WindowSingleThreaded::render);
+
+    // Now hook up the signals. For simplicy we don't differentiate between
+    // renderRequested (only render is needed, no sync) and sceneChanged (polish and sync
+    // is needed too).
+    connect(m_quickWindow, &QQuickWindow::sceneGraphInitialized, this, &WindowSingleThreaded::createTexture);
+    connect(m_quickWindow, &QQuickWindow::sceneGraphInvalidated, this, &WindowSingleThreaded::destroyTexture);
+    connect(m_renderControl, &QQuickRenderControl::renderRequested, this, &WindowSingleThreaded::requestUpdate);
+    connect(m_renderControl, &QQuickRenderControl::sceneChanged, this, &WindowSingleThreaded::requestUpdate);
+
+    // Just recreating the texture on resize is not sufficient, when moving between screens
+    // with different devicePixelRatio the QWindow size may remain the same but the texture
+    // dimension is to change regardless.
+    connect(this, &QWindow::screenChanged, this, &WindowSingleThreaded::handleScreenChange);
+}
+
+WindowSingleThreaded::~WindowSingleThreaded()
+{
+    // Make sure the context is current while doing cleanup. Note that we use the
+    // offscreen surface here because passing 'this' at this point is not safe: the
+    // underlying platform window may already be destroyed. To avoid all the trouble, use
+    // another surface that is valid for sure.
+    m_glContext->makeCurrent(m_offscreenSurface);
+
+    delete m_qmlComponent;
+    delete m_qmlEngine;
+    delete m_quickWindow;
+    delete m_renderControl;
+
+    if (m_textureId)
+        m_glContext->functions()->glDeleteTextures(1, &m_textureId);
+
+    delete m_program;
+    delete m_vbo;
+    delete m_vao;
+
+    m_glContext->doneCurrent();
+
+    delete m_offscreenSurface;
+    delete m_glContext;
+}
+
+void WindowSingleThreaded::setHitTestVisible(QQuickItem *item, bool value)
+{
+    __flh_ns::FramelessWindowsManager::setHitTestVisible(this, item, value);
+}
+
+void WindowSingleThreaded::createTexture()
+{
+    // The scene graph has been initialized. It is now time to create an texture and associate
+    // it with the QQuickWindow.
+    m_dpr = devicePixelRatio();
+    m_textureSize = size() * m_dpr;
+    QOpenGLFunctions *f = m_glContext->functions();
+    f->glGenTextures(1, &m_textureId);
+    f->glBindTexture(GL_TEXTURE_2D, m_textureId);
+    f->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    f->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    f->glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_textureSize.width(), m_textureSize.height(), 0,
+                    GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    m_quickWindow->setRenderTarget(QQuickRenderTarget::fromOpenGLTexture(m_textureId, m_textureSize));
+}
+
+void WindowSingleThreaded::destroyTexture()
+{
+    m_glContext->functions()->glDeleteTextures(1, &m_textureId);
+    m_textureId = 0;
+}
+
+
+void WindowSingleThreaded::init()
+{
+    m_sharedGLContext = new QOpenGLContext;
+    m_sharedGLContext->setShareContext(m_glContext);
+    m_sharedGLContext->setFormat(this->requestedFormat());
+    m_sharedGLContext->create();
+
+    if (!m_sharedGLContext->makeCurrent(this))
+        return;
+
+    QOpenGLFunctions *f = m_sharedGLContext->functions();
+    f->glClearColor(0.0f, 0.1f, 0.25f, 1.0f);
+    f->glViewport(0, 0, this->width() * this->devicePixelRatio(), this->height() * this->devicePixelRatio());
+
+    static const char *vertexShaderSource =
+        "attribute highp vec4 vertexIn;\n"
+        "attribute lowp vec2 vertTexCoord;\n"
+        "varying lowp vec2 fragTexCoord;\n"
+        "void main() {\n"
+        "   fragTexCoord = vertTexCoord;\n"
+        "   gl_Position = vertexIn;\n"
+        "}\n";
+
+    static const char *fragmentShaderSource =
+        "uniform lowp sampler2D tex;\n"
+        "varying vec2 fragTexCoord;\n"
+        "void main(void)\n"
+        "{\n"
+        "    gl_FragColor = texture2D(tex, fragTexCoord);\n"
+        "    //gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);\n"
+        "}\n";
+
+    m_program = new QOpenGLShaderProgram;
+    m_program->addCacheableShaderFromSourceCode(QOpenGLShader::Vertex, vertexShaderSource);
+    m_program->addCacheableShaderFromSourceCode(QOpenGLShader::Fragment, fragmentShaderSource);
+    m_program->bindAttributeLocation("vertexIn", 0);
+    m_program->bindAttributeLocation("vertTexCoord", 1);
+    m_program->link();
+
+    f->glUseProgram(m_program->programId());
+
+    m_program->setUniformValue("tex", 0);
+
+    int t1 = f->glGetUniformLocation(m_program->programId(), "tex");
+    f->glUniform1i(t1, 0);
+
+    m_vao = new QOpenGLVertexArrayObject;
+    m_vao->create();
+    QOpenGLVertexArrayObject::Binder vaoBinder(m_vao);
+
+    m_vbo = new QOpenGLBuffer;
+    m_vbo->create();
+    m_vbo->bind();
+
+    GLfloat v[] = {-1.0,-1.0, 1.0,-1.0, 1.0,1.0,
+                   1.0,1.0, -1.0,1.0, -1.0,-1.0};
+
+    GLfloat texCoords[] = {0.0,0.0, 1.0,0.0, 1.0,1.0,
+                           1.0,1.0, 0.0,1.0, 0.0,0.0};
+
+    const int vertexCount = 6;
+    m_vbo->allocate(sizeof(GLfloat) * vertexCount * 4);
+    m_vbo->write(0, v, sizeof(GLfloat) * vertexCount * 2);
+    m_vbo->write(sizeof(GLfloat) * vertexCount * 2, texCoords, sizeof(GLfloat) * vertexCount * 2);
+    m_vbo->release();
+
+    if (m_vao->isCreated())
+        setupVertexAttribs();
+}
+
+void WindowSingleThreaded::setupVertexAttribs()
+{
+    m_vbo->bind();
+    m_program->enableAttributeArray(0);
+    m_program->enableAttributeArray(1);
+    m_sharedGLContext->functions()->glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
+    m_sharedGLContext->functions()->glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0,
+                                                  (const void *)(6 * 2 * sizeof(GLfloat)));
+    m_vbo->release();
+}
+
+void WindowSingleThreaded::renderGL()
+{
+    if (!this->m_sharedGLContext) {
+        this->init();
+    }
+
+    if (!this->m_sharedGLContext->makeCurrent(this)) {
+        return;
+    }
+
+    QOpenGLFunctions *f = m_sharedGLContext->functions();
+    f->glViewport(0, 0, this->width() * this->devicePixelRatio(), this->height() * this->devicePixelRatio());
+    f->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    uint texture = m_quickReady ? m_textureId : 0;
+    if (texture) {
+        f->glEnable(GL_CULL_FACE);
+        f->glEnable(GL_DEPTH_TEST);
+
+        m_program->bind();
+
+        QOpenGLVertexArrayObject::Binder vaoBinder(m_vao);
+
+        // If VAOs are not supported, set the vertex attributes every time.
+        if (!m_vao->isCreated()) {
+            qDebug() << "not created";
+            setupVertexAttribs();
+        }
+
+        f->glActiveTexture(GL_TEXTURE0 + 0);
+        f->glBindTexture(GL_TEXTURE_2D, texture);
+
+        // Draw the verticies.
+        f->glDrawArrays(GL_TRIANGLES, 0, 6);
+
+        f->glBindTexture(GL_TEXTURE_2D, 0);
+
+        m_sharedGLContext->swapBuffers(this);
+    }
+}
+
+void WindowSingleThreaded::render()
+{
+    if (!m_glContext->makeCurrent(m_offscreenSurface))
+        return;
+
+    // Polish, synchronize and render the next frame (into our texture).  In this example
+    // everything happens on the same thread and therefore all three steps are performed
+    // in succession from here. In a threaded setup the render() call would happen on a
+    // separate thread.
+    m_renderControl->beginFrame();
+    m_renderControl->polishItems();
+    m_renderControl->sync();
+    m_renderControl->render();
+    m_renderControl->endFrame();
+
+    QOpenGLFramebufferObject::bindDefault();
+    m_glContext->functions()->glFlush();
+
+    m_quickReady = true;
+    this->renderGL();
+}
+
+void WindowSingleThreaded::requestUpdate()
+{
+    if (!m_updateTimer.isActive())
+        m_updateTimer.start();
+}
+
+void WindowSingleThreaded::run()
+{
+    disconnect(m_qmlComponent, &QQmlComponent::statusChanged, this, &WindowSingleThreaded::run);
+
+    if (m_qmlComponent->isError()) {
+        const QList<QQmlError> errorList = m_qmlComponent->errors();
+        for (const QQmlError &error : errorList)
+            qWarning() << error.url() << error.line() << error;
+        return;
+    }
+
+    QObject *rootObject = m_qmlComponent->create();
+    if (m_qmlComponent->isError()) {
+        const QList<QQmlError> errorList = m_qmlComponent->errors();
+        for (const QQmlError &error : errorList)
+            qWarning() << error.url() << error.line() << error;
+        return;
+    }
+
+    m_rootItem = qobject_cast<QQuickItem *>(rootObject);
+    if (!m_rootItem) {
+        qWarning("run: Not a QQuickItem");
+        delete rootObject;
+        return;
+    }
+
+    // The root item is ready. Associate it with the window.
+    m_rootItem->setParentItem(m_quickWindow->contentItem());
+
+    // Required otherwise frameless helper will not be able to determine the
+    // actual displayed window
+    m_rootItem->setParent(m_quickWindow->contentItem());
+
+    // Update item and rendering related geometries.
+    updateSizes();
+
+    // Ensure key events are received by the root Rectangle.
+    m_rootItem->forceActiveFocus();
+
+    // Initialize the render control and our OpenGL resources.
+    m_glContext->makeCurrent(m_offscreenSurface);
+    m_quickWindow->setGraphicsDevice(QQuickGraphicsDevice::fromOpenGLContext(m_glContext));
+    m_renderControl->initialize();
+}
+
+void WindowSingleThreaded::updateSizes()
+{
+    // Behave like SizeRootObjectToView.
+    m_rootItem->setWidth(width());
+    m_rootItem->setHeight(height());
+
+    m_quickWindow->setGeometry(0, 0, width(), height());
+}
+
+void WindowSingleThreaded::startQuick(const QString &filename)
+{
+    m_qmlComponent = new QQmlComponent(m_qmlEngine, QUrl(filename));
+    if (m_qmlComponent->isLoading())
+        connect(m_qmlComponent, &QQmlComponent::statusChanged, this, &WindowSingleThreaded::run);
+    else
+        run();
+}
+
+void WindowSingleThreaded::exposeEvent(QExposeEvent *)
+{
+    if (isExposed()) {
+        if (!m_qmlComponent) {
+            this->renderGL();
+            startQuick(QStringLiteral("qrc:/rendercontrol/qml/main.qml"));
+        }
+    }
+}
+
+void WindowSingleThreaded::showEvent(QShowEvent *e)
+{
+#ifndef Q_OS_WASM
+    if(!m_isFWMInitalised)
+    {
+        this->m_isFWMInitalised = true;
+        __flh_ns::FramelessWindowsManager::addWindow(this);
+        __flh_ns::FramelessWindowsManager::setTitleBarHeight(this, this->m_titleBarHeight);
+    }
+#endif
+}
+
+void WindowSingleThreaded::resizeTexture()
+{
+    if (m_rootItem && m_glContext->makeCurrent(m_offscreenSurface)) {
+        this->destroyTexture();
+        createTexture();
+        m_glContext->doneCurrent();
+        updateSizes();
+        render();
+    }
+}
+
+void WindowSingleThreaded::resizeEvent(QResizeEvent *)
+{
+    // If this is a resize after the scene is up and running, recreate the texture and the
+    // Quick item and scene.
+    if (m_textureId && m_textureSize != size() * devicePixelRatio()) {
+        resizeTexture();
+    }
+}
+
+void WindowSingleThreaded::handleScreenChange()
+{
+    if (m_dpr != devicePixelRatio())
+        resizeTexture();
+}
+
+void WindowSingleThreaded::mousePressEvent(QMouseEvent *e)
+{
+    // Use the constructor taking position and globalPosition. That puts position into the
+    // event's position and scenePosition, and globalPosition into the event's globalPosition. This way
+    // the scenePosition in e is ignored and is replaced by position. This is necessary
+    // because QQuickWindow thinks of itself as a top-level window always.
+    QMouseEvent mappedEvent(e->type(), e->position(), e->globalPosition(), e->button(), e->buttons(), e->modifiers());
+    QCoreApplication::sendEvent(m_quickWindow, &mappedEvent);
+}
+
+void WindowSingleThreaded::mouseReleaseEvent(QMouseEvent *e)
+{
+    QMouseEvent mappedEvent(e->type(), e->position(), e->globalPosition(), e->button(), e->buttons(), e->modifiers());
+    QCoreApplication::sendEvent(m_quickWindow, &mappedEvent);
+}
+
+void WindowSingleThreaded::keyPressEvent(QKeyEvent *e)
+{
+    QCoreApplication::sendEvent(m_quickWindow, e);
+}
+
+void WindowSingleThreaded::keyReleaseEvent(QKeyEvent *e)
+{
+    QCoreApplication::sendEvent(m_quickWindow, e);
+}
+
+int WindowSingleThreaded::getTitleBarHeight() const
+{
+    return this->m_titleBarHeight;
+}

--- a/examples/rendercontrol_opengl/window_singlethreaded.cpp
+++ b/examples/rendercontrol_opengl/window_singlethreaded.cpp
@@ -454,6 +454,12 @@ void WindowSingleThreaded::handleScreenChange()
         resizeTexture();
 }
 
+void WindowSingleThreaded::mouseMoveEvent(QMouseEvent *e)
+{
+    QMouseEvent mappedEvent(e->type(), e->position(), e->globalPosition(), e->button(), e->buttons(), e->modifiers());
+    QCoreApplication::sendEvent(m_quickWindow, &mappedEvent);
+}
+
 void WindowSingleThreaded::mousePressEvent(QMouseEvent *e)
 {
     // Use the constructor taking position and globalPosition. That puts position into the

--- a/examples/rendercontrol_opengl/window_singlethreaded.h
+++ b/examples/rendercontrol_opengl/window_singlethreaded.h
@@ -1,0 +1,126 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the examples of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:BSD$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** BSD License Usage
+** Alternatively, you may use this file under the terms of the BSD license
+** as follows:
+**
+** "Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are
+** met:
+**   * Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**   * Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in
+**     the documentation and/or other materials provided with the
+**     distribution.
+**   * Neither the name of The Qt Company Ltd nor the names of its
+**     contributors may be used to endorse or promote products derived
+**     from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#pragma once
+
+#include <QtGui/QWindow>
+#include <QtCore/QTimer>
+
+class QOpenGLBuffer;
+class QOpenGLContext;
+class QOpenGLShaderProgram;
+class QOpenGLTexture;
+class QOpenGLVertexArrayObject;
+class QOffscreenSurface;
+class QQuickRenderControl;
+class QQuickWindow;
+class QQmlEngine;
+class QQmlComponent;
+class QQuickItem;
+
+class WindowSingleThreaded : public QWindow
+{
+    Q_OBJECT
+    Q_PROPERTY(qint64 titleBarHeight READ getTitleBarHeight CONSTANT)
+
+public:
+    WindowSingleThreaded();
+    ~WindowSingleThreaded();
+
+    Q_INVOKABLE
+    void setHitTestVisible(QQuickItem *item, bool value);
+    int getTitleBarHeight() const;
+
+protected:
+    void exposeEvent(QExposeEvent *e) override;
+    void resizeEvent(QResizeEvent *e) override;
+    void showEvent(QShowEvent *e) override;
+    void mousePressEvent(QMouseEvent *e) override;
+    void mouseReleaseEvent(QMouseEvent *e) override;
+    void keyPressEvent(QKeyEvent *e) override;
+    void keyReleaseEvent(QKeyEvent *e) override;
+
+private Q_SLOTS:
+    void run();
+
+    void createTexture();
+    void destroyTexture();
+    void render();
+    void renderGL();
+    void init();
+    void setupVertexAttribs();
+    void requestUpdate();
+    void handleScreenChange();
+
+private:
+    void startQuick(const QString &filename);
+    void updateSizes();
+    void resizeTexture();
+
+    QOpenGLContext *m_glContext{nullptr};
+    QOpenGLContext *m_sharedGLContext{nullptr};
+    QOffscreenSurface *m_offscreenSurface{nullptr};
+    QQuickRenderControl *m_renderControl{nullptr};
+    QQuickWindow *m_quickWindow{nullptr};
+    QQmlEngine *m_qmlEngine{nullptr};
+    QQmlComponent *m_qmlComponent{nullptr};
+    QQuickItem *m_rootItem{nullptr};
+    uint m_textureId{0};
+    QSize m_textureSize;
+    bool m_quickReady{false};
+    QTimer m_updateTimer;
+    qreal m_dpr{0};
+    bool m_isFWMInitalised{false};
+    int m_titleBarHeight{26};
+
+    QOpenGLShaderProgram *m_program{nullptr};
+    QOpenGLBuffer *m_vbo{nullptr};
+    QOpenGLVertexArrayObject *m_vao{nullptr};
+};

--- a/examples/rendercontrol_opengl/window_singlethreaded.h
+++ b/examples/rendercontrol_opengl/window_singlethreaded.h
@@ -119,7 +119,7 @@ private:
     QTimer m_updateTimer;
     qreal m_dpr{0};
     bool m_isFWMInitalised{false};
-    int m_titleBarHeight{26};
+    int m_titleBarHeight{30};
 
     QOpenGLShaderProgram *m_program{nullptr};
     QOpenGLBuffer *m_vbo{nullptr};

--- a/examples/rendercontrol_opengl/window_singlethreaded.h
+++ b/examples/rendercontrol_opengl/window_singlethreaded.h
@@ -82,6 +82,7 @@ protected:
     void exposeEvent(QExposeEvent *e) override;
     void resizeEvent(QResizeEvent *e) override;
     void showEvent(QShowEvent *e) override;
+    void mouseMoveEvent(QMouseEvent *e) override;
     void mousePressEvent(QMouseEvent *e) override;
     void mouseReleaseEvent(QMouseEvent *e) override;
     void keyPressEvent(QKeyEvent *e) override;

--- a/utilities.cpp
+++ b/utilities.cpp
@@ -85,7 +85,7 @@ bool Utilities::isHitTestVisible(const QWindow *window)
         if (!obj->property("visible").toBool()) {
             continue;
         }
-        const QPointF originPoint = mapOriginPointToWindow(obj);
+        const QPointF originPoint = mapOriginPointToWindow(obj, window);
         const qreal width = obj->property("width").toReal();
         const qreal height = obj->property("height").toReal();
         const QRectF rect = {originPoint.x(), originPoint.y(), width, height};
@@ -96,7 +96,7 @@ bool Utilities::isHitTestVisible(const QWindow *window)
     return false;
 }
 
-QPointF Utilities::mapOriginPointToWindow(const QObject *object)
+QPointF Utilities::mapOriginPointToWindow(const QObject *object, const QWindow *window)
 {
     Q_ASSERT(object);
     if (!object) {
@@ -110,6 +110,12 @@ QPointF Utilities::mapOriginPointToWindow(const QObject *object)
     for (QObject *parent = object->parent(); parent; parent = parent->parent()) {
         point += {parent->property("x").toReal(), parent->property("y").toReal()};
         if (parent->isWindowType()) {
+            // The QWindows may be different in which case assume the QObject is
+            // embedded within a QQuickRenderControl itself within the main
+            // frameless window.
+            if (parent != window) {
+                point += window->position();
+            }
             break;
         }
     }

--- a/utilities.h
+++ b/utilities.h
@@ -36,7 +36,7 @@ namespace Utilities
 [[nodiscard]] FRAMELESSHELPER_API QWindow *findWindow(const WId winId);
 [[nodiscard]] FRAMELESSHELPER_API bool isWindowFixedSize(const QWindow *window);
 [[nodiscard]] FRAMELESSHELPER_API bool isHitTestVisible(const QWindow *window);
-[[nodiscard]] FRAMELESSHELPER_API QPointF mapOriginPointToWindow(const QObject *object);
+[[nodiscard]] FRAMELESSHELPER_API QPointF mapOriginPointToWindow(const QObject *object, const QWindow *window);
 [[nodiscard]] FRAMELESSHELPER_API QColor getColorizationColor();
 [[nodiscard]] FRAMELESSHELPER_API int getWindowVisibleFrameBorderThickness(const WId winId);
 [[nodiscard]] FRAMELESSHELPER_API bool shouldAppsUseDarkMode();


### PR DESCRIPTION
If the main applications content is being rendered via an off-screen [QQuickRenderControl ](https://doc.qt.io/qt-6/qquickrendercontrol.html) into a host frameless [QWindow](https://doc.qt.io/qt-6/qwindow.html) then framelesshelper needs to take into account the host windows offset when hit testing. This is required as the hidden QQuickWindow that is used by QQuickRenderControl is not the same window as the host QWindow that is actually shown. As a result their positions are not the same so the `Utilities::mapOriginPointToWindow` does not calculate the correct mapping offset.

This PR fixes the above and allows for creating your own custom title bar controls within the QQuickRenderControl's content as otherwise mouse events will not be mapped correctly.

