### PR TITLE
A fixing for Visual C++ 2019 compiling error C2220

### DIFF
--- a/src/core/framelesswindowsmanager.cpp
+++ b/src/core/framelesswindowsmanager.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * MIT License
  *
  * Copyright (C) 2022 by wangwenx190 (Yuhang Zhao)
@@ -30,6 +30,7 @@
 #include <QtGui/qguiapplication.h>
 #include <QtGui/qscreen.h>
 #include <QtGui/qwindow.h>
+#include <QDir>
 #include "framelesshelper_qt.h"
 #include "utils.h"
 #ifdef Q_OS_WINDOWS
@@ -97,7 +98,8 @@ bool FramelessWindowsManagerPrivate::usePureQtImplementation()
         if (qEnvironmentVariableIntValue(kUsePureQtImplFlag) != 0) {
             return true;
         }
-        const QString iniFilePath = QCoreApplication::applicationDirPath() + QChar(u'/') + kConfigFileName;
+        QDir dir(QCoreApplication::applicationDirPath());
+        const QString iniFilePath = dir.filePath(kConfigFileName);
         QSettings settings(iniFilePath, QSettings::IniFormat);
         return settings.value(kUsePureQtImplKeyPath, false).toBool();
     }();

--- a/src/quick/framelessquickhelper.cpp
+++ b/src/quick/framelessquickhelper.cpp
@@ -64,7 +64,7 @@ void FramelessHelper::Quick::registerTypes(QQmlEngine *engine)
     qRegisterMetaType<QuickGlobal::DwmColorizationArea>();
     qRegisterMetaType<QuickGlobal::Anchor>();
     qRegisterMetaType<QuickGlobal::ButtonState>();
-#ifdef Q_CC_MSVC
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning( disable : 4127 ) // "conditional expression is constant"
 #endif
@@ -76,7 +76,7 @@ void FramelessHelper::Quick::registerTypes(QQmlEngine *engine)
             Q_UNUSED(scriptEngine);
             return new FramelessQuickUtils;
         });
-#ifdef Q_CC_MSVC
+#ifdef _MSC_VER
 #pragma warning(pop)
 #endif
     qmlRegisterRevision<QWindow, 254>(QUICK_URI_FULL);

--- a/src/quick/framelessquickhelper.cpp
+++ b/src/quick/framelessquickhelper.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * MIT License
  *
  * Copyright (C) 2022 by wangwenx190 (Yuhang Zhao)
@@ -64,6 +64,10 @@ void FramelessHelper::Quick::registerTypes(QQmlEngine *engine)
     qRegisterMetaType<QuickGlobal::DwmColorizationArea>();
     qRegisterMetaType<QuickGlobal::Anchor>();
     qRegisterMetaType<QuickGlobal::ButtonState>();
+#ifdef Q_CC_MSVC
+#pragma warning(push)
+#pragma warning( disable : 4127 ) // "conditional expression is constant"
+#endif
     qmlRegisterUncreatableType<QuickGlobal>(QUICK_URI_FULL, "FramelessHelper",
         FRAMELESSHELPER_STRING_LITERAL("The FramelessHelper namespace is not creatable, you can only use it to access it's enums."));
     qmlRegisterSingletonType<FramelessQuickUtils>(QUICK_URI_EXPAND("FramelessUtils"),
@@ -72,6 +76,9 @@ void FramelessHelper::Quick::registerTypes(QQmlEngine *engine)
             Q_UNUSED(scriptEngine);
             return new FramelessQuickUtils;
         });
+#ifdef Q_CC_MSVC
+#pragma warning(pop)
+#endif
     qmlRegisterRevision<QWindow, 254>(QUICK_URI_FULL);
     qmlRegisterRevision<QQuickWindow, 254>(QUICK_URI_FULL);
     qmlRegisterRevision<QQuickItem, 254>(QUICK_URI_FULL);

--- a/src/quick/framelessquickwindow.cpp
+++ b/src/quick/framelessquickwindow.cpp
@@ -28,7 +28,6 @@
 #pragma warning( disable : 4193 )
 #pragma warning( disable : 4201 )
 #pragma warning( disable : 4458 )
-#pragma warning( disable : 4458 )
 #endif
 
 #include "framelessquickwindow.h"

--- a/src/quick/framelessquickwindow.cpp
+++ b/src/quick/framelessquickwindow.cpp
@@ -39,6 +39,9 @@
 #include <framelesswindowsmanager.h>
 #include <utils.h>
 
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 FRAMELESSHELPER_BEGIN_NAMESPACE
 
@@ -966,9 +969,7 @@ void FramelessQuickWindow::startSystemResize2(const Qt::Edges edges, const QPoin
     d->startSystemResize2(edges, pos);
 }
 
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+
 
 
 FRAMELESSHELPER_END_NAMESPACE

--- a/src/quick/framelessquickwindow.cpp
+++ b/src/quick/framelessquickwindow.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * MIT License
  *
  * Copyright (C) 2022 by wangwenx190 (Yuhang Zhao)
@@ -22,6 +22,15 @@
  * SOFTWARE.
  */
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning( disable : 4127 )
+#pragma warning( disable : 4193 )
+#pragma warning( disable : 4201 )
+#pragma warning( disable : 4458 )
+#pragma warning( disable : 4458 )
+#endif
+
 #include "framelessquickwindow.h"
 #include "framelessquickwindow_p.h"
 #include <QtQuick/private/qquickitem_p.h>
@@ -29,6 +38,7 @@
 #include <QtQuick/private/qquickanchors_p.h>
 #include <framelesswindowsmanager.h>
 #include <utils.h>
+
 
 FRAMELESSHELPER_BEGIN_NAMESPACE
 
@@ -801,6 +811,7 @@ void FramelessQuickWindowPrivate::updateTopBorderHeight()
 #endif
 }
 
+
 FramelessQuickWindow::FramelessQuickWindow(QWindow *parent, const UserSettings &settings) : QQuickWindow(parent)
 {
     d_ptr.reset(new FramelessQuickWindowPrivate(this, settings));
@@ -954,5 +965,10 @@ void FramelessQuickWindow::startSystemResize2(const Qt::Edges edges, const QPoin
     Q_D(FramelessQuickWindow);
     d->startSystemResize2(edges, pos);
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 
 FRAMELESSHELPER_END_NAMESPACE


### PR DESCRIPTION
The issue https://github.com/wangwenx190/framelesshelper/issues/123 is a partial explanations of the PR, but not all.
At first I thought it is caused only by the combination of C4127 and C2220, then I found C4193/C4201/C4458 as like. 
The main cause is that the Qt5 ( I have not make testing under Qt6) is unfriendly with option /Wx of Visual C++ compiler.  So I try to:
- make some change to the framelesshelper , like framelesswindowsmanager.cpp at 101
- otherwise, use '#program warning' to disable warnings which happen inside codes of Qt, and try not to make influence to framelesshelper
