### PR TITLE
修改了几个地方

### DIFF
--- a/include/FramelessHelper/Core/framelesshelper_windows.h
+++ b/include/FramelessHelper/Core/framelesshelper_windows.h
@@ -159,16 +159,24 @@
 
 using NTSTATUS = LONG;
 
+#ifndef WINMMAPI
+
+EXTERN_C_START
+#   define WINMMAPI DECLSPEC_IMPORT
+EXTERN_C_END
+
 using MMRESULT = UINT;
 
-using TIMECAPS = struct TIMECAPS
-{
+using TIMECAPS = struct TIMECAPS {
     UINT wPeriodMin; // minimum period supported
     UINT wPeriodMax; // maximum period supported
 };
+
 using PTIMECAPS = TIMECAPS *;
 using NPTIMECAPS = TIMECAPS NEAR *;
 using LPTIMECAPS = TIMECAPS FAR *;
+
+#endif
 
 using PROCESS_DPI_AWARENESS = enum PROCESS_DPI_AWARENESS
 {
@@ -284,18 +292,18 @@ using LPWINDOWCOMPOSITIONATTRIBDATA = WINDOWCOMPOSITIONATTRIBDATA FAR *;
 using GetWindowCompositionAttributePtr = BOOL(WINAPI *)(HWND, PWINDOWCOMPOSITIONATTRIBDATA);
 using SetWindowCompositionAttributePtr = BOOL(WINAPI *)(HWND, PWINDOWCOMPOSITIONATTRIBDATA);
 
-EXTERN_C MMRESULT WINAPI
+WINMMAPI MMRESULT WINAPI
 timeGetDevCaps(
     _Out_writes_bytes_(cbtc) LPTIMECAPS ptc,
     _In_ UINT cbtc
 );
 
-EXTERN_C MMRESULT WINAPI
+WINMMAPI MMRESULT WINAPI
 timeBeginPeriod(
     _In_ UINT uPeriod
 );
 
-EXTERN_C MMRESULT WINAPI
+WINMMAPI MMRESULT WINAPI
 timeEndPeriod(
     _In_ UINT uPeriod
 );
@@ -322,6 +330,11 @@ GetSystemMetricsForDpi(
 WINUSERAPI UINT WINAPI
 GetDpiForWindow(
     _In_ HWND hwnd
+);
+
+WINUSERAPI UINT WINAPI
+GetDpiForSystem(
+    VOID
 );
 
 WINUSERAPI UINT WINAPI

--- a/include/FramelessHelper/Core/framelesshelper_windows.h
+++ b/include/FramelessHelper/Core/framelesshelper_windows.h
@@ -161,17 +161,15 @@ using NTSTATUS = LONG;
 
 #ifndef WINMMAPI
 
-EXTERN_C_START
-#   define WINMMAPI DECLSPEC_IMPORT
-EXTERN_C_END
+#define WINMMAPI EXTERN_C DECLSPEC_IMPORT
 
 using MMRESULT = UINT;
 
-using TIMECAPS = struct TIMECAPS {
+using TIMECAPS = struct TIMECAPS
+{
     UINT wPeriodMin; // minimum period supported
     UINT wPeriodMax; // maximum period supported
 };
-
 using PTIMECAPS = TIMECAPS *;
 using NPTIMECAPS = TIMECAPS NEAR *;
 using LPTIMECAPS = TIMECAPS FAR *;

--- a/include/FramelessHelper/Core/private/sysapiloader_p.h
+++ b/include/FramelessHelper/Core/private/sysapiloader_p.h
@@ -29,6 +29,8 @@
 #include <QtCore/qhash.h>
 #include <QtCore/qmutex.h>
 
+#include <optional>
+
 FRAMELESSHELPER_BEGIN_NAMESPACE
 
 class FRAMELESSHELPER_CORE_API SysApiLoader : public QObject

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -64,6 +64,7 @@ if(WIN32)
         framelesshelper_win.cpp
     )
 elseif(APPLE)
+    set(CMAKE_SHARED_LINKER_FLAGS "-framework ServiceManagement -framework Foundation -framework Cocoa")
     list(APPEND SOURCES utils_mac.mm)
 elseif(UNIX)
     list(APPEND SOURCES utils_linux.cpp)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -64,7 +64,6 @@ if(WIN32)
         framelesshelper_win.cpp
     )
 elseif(APPLE)
-    set(CMAKE_SHARED_LINKER_FLAGS "-framework ServiceManagement -framework Foundation -framework Cocoa")
     list(APPEND SOURCES utils_mac.mm)
 elseif(UNIX)
     list(APPEND SOURCES utils_linux.cpp)
@@ -126,7 +125,12 @@ else()
     )
 endif()
 
-if(UNIX AND NOT APPLE)
+if (APPLE)
+    target_link_libraries(${SUB_PROJ_NAME} PRIVATE
+        "-framework Foundation"
+        "-framework Cocoa"
+    )
+elseif (UNIX)
     target_compile_definitions(${SUB_PROJ_NAME} PRIVATE
         GDK_VERSION_MIN_REQUIRED=GDK_VERSION_3_6
     )

--- a/src/core/framelessmanager.cpp
+++ b/src/core/framelessmanager.cpp
@@ -25,6 +25,7 @@
 #include "framelessmanager.h"
 #include "framelessmanager_p.h"
 #include <QtCore/qmutex.h>
+#include <QtCore/qdebug.h>
 #include <QtGui/qguiapplication.h>
 #include <QtGui/qscreen.h>
 #include <QtGui/qwindow.h>


### PR DESCRIPTION
+ 在MinGW下面，好像莫名其妙已经包含了`<mmsystem.h>`，所以`struct TIMECAPS`会出现重复定义，这里用`WINMMAPI`的宏作为判断，如果已经定义就忽略掉。

+ 上次我比较的版本是2.x里比较早的一个，那么就漏了一个`GetDpiForSystem`，这里补上了。

+ `time`的三个函数补充了`dllimport`，不然会重复定义。

+ `apiloader`那里不管哪个编译器都没有包含`std::optional`，所以补了一个`#include <optional>`。

+ `CMakeLists`里面加了MacOS系统库的链接，不然过不了编译。

+ 最后还有个比较致命的问题，就是`SetProcessDPIAware`这个函数MinGW找不到实现，报错信息是
````
error: undefined reference to `__imp__Z18SetProcessDPIAwarev'
````

+ MinGW的`winuser.h`里是这样的
````
#if _WIN32_WINNT >= 0x0600
#define USER_DEFAULT_SCREEN_DPI 96

  WINUSERAPI WINBOOL WINAPI SetProcessDPIAware (VOID);
  WINUSERAPI WINBOOL WINAPI IsProcessDPIAware (VOID);
#endif
````
而这个VERSION是不满足的，MinGW里的`_WIN32_WINNT`是0x0502，不知道是不是这个原因所以MinGW的二进制里没有到`user32.dll`的链接，我把这个函数删了就通过编译了，好像也没什么区别。