### PR TITLE
win: fix build with Qt 5.14 and MinGW

### DIFF
--- a/include/FramelessHelper/Widgets/private/widgetssharedhelper_p.h
+++ b/include/FramelessHelper/Widgets/private/widgetssharedhelper_p.h
@@ -68,11 +68,11 @@ Q_SIGNALS:
     void micaEnabledChanged();
 
 private:
-    QPointer<QWidget> m_targetWidget = nullptr;
+    QPointer<QWidget> m_targetWidget;
     bool m_micaEnabled = false;
     QPointer<MicaMaterial> m_micaMaterial;
     QMetaObject::Connection m_micaRedrawConnection = {};
-    QPointer<QScreen> m_screen = nullptr;
+    QPointer<QScreen> m_screen;
     qreal m_screenDpr = 0.0;
     QMetaObject::Connection m_screenDpiChangeConnection = {};
 };


### PR DESCRIPTION
This fixes my problems using QPointer in ``widgetssharedhelper_p.h``. Instead of using a raw pointer, we are still using QPointer. It could be possible to do an extended check somewhere if the pointer is already declared, example:
```
QPointer<QWidget> m_widget;
if (!m_widget) // if not already there
    m_widget = new QWidget;
```