### PR TITLE
gcc and qt-5.12.0 compilation error fix

### DIFF
--- a/include/FramelessHelper/Core/private/sysapiloader_p.h
+++ b/include/FramelessHelper/Core/private/sysapiloader_p.h
@@ -56,7 +56,7 @@ public:
     }
 
 private:
-    static inline QMutex m_mutex;
+    static inline QMutex m_mutex{};
     static inline QHash<QString, std::optional<QFunctionPointer>> m_functionCache = {};
 };
 


### PR DESCRIPTION
Compililation with gcc (any version) and Qt 5.12.0 (important) fails with error:
```
Core/private/sysapiloader_p.h:59:26: error: no matching function for call to ‘QMutex::QMutex()’
     static inline QMutex m_mutex;
                          ^~~~~~~
include/QtCore/qmutex.h:165:5: note: candidate: ‘QMutex::QMutex(const QMutex&)’ <deleted>
     Q_DISABLE_COPY(QMutex)
     ^~~~~~~~~~~~~~
```

`QMutex` in Qt 5.12.0 has explicit (!) one-parameter constructor with a default value: `QMutex(QMutex::RecursionMode mode = NonRecursive)` and no default constructor. In this case declaring static inline member without initializer causes the above error.

Simplified example: https://godbolt.org/z/KzeK1nfYf