### PR TITLE
call gtk_init() before gtk_settings_get_default()

### DIFF
--- a/src/core/framelesshelpercore_global.cpp
+++ b/src/core/framelesshelpercore_global.cpp
@@ -43,6 +43,9 @@
 #endif
 #include <QtCore/qmutex.h>
 #include <QtGui/qguiapplication.h>
+#ifdef Q_OS_LINUX
+#  include <gtk/gtk.h>
+#endif
 
 #ifndef COMPILER_STRING
 #  ifdef Q_CC_CLANG // Must be before GNU, because Clang claims to be GNU too.
@@ -110,6 +113,10 @@ void initialize()
         return;
     }
     inited = true;
+
+#ifdef Q_OS_LINUX
+    gtk_init(nullptr, nullptr);
+#endif
 
 #ifdef Q_OS_LINUX
     // Qt's Wayland experience is not good, so we force the XCB backend here.


### PR DESCRIPTION
As stated in GTK documentation about gtk_init():

* "Call this function before using any other GTK+ functions in your GUI applications. It will initialize everything needed to operate the toolkit and parses some standard command line options."

* "It is possible to pass NULL if argv is not available or commandline handling is not required."

Fixes: #170