### PR TITLE
Fix the native titlebar buttons don't show in Qt 6.0.0 - Qt 6.2.4.

### DIFF
--- a/src/core/utils_mac.mm
+++ b/src/core/utils_mac.mm
@@ -361,9 +361,11 @@ public Q_SLOTS:
         nswindow.showsToolbarButton = NO;
         nswindow.movableByWindowBackground = NO;
         nswindow.movable = NO;
+#if !(QT_VERSION >= QT_VERSION_CHECK(6,0,0) && QT_VERSION <= QT_VERSION_CHECK(6,2,4))
         [nswindow standardWindowButton:NSWindowCloseButton].hidden = (visible ? NO : YES);
         [nswindow standardWindowButton:NSWindowMiniaturizeButton].hidden = (visible ? NO : YES);
         [nswindow standardWindowButton:NSWindowZoomButton].hidden = (visible ? NO : YES);
+#endif
     }
 
     void setBlurBehindWindowEnabled(const bool enable)


### PR DESCRIPTION
修复macOS下使用Qt 6.0.0 - Qt 6.2.4版本下编译，不显示原生标题栏按钮的问题。