### PR TITLE
Fix the native titlebar buttons don't show below Qt 6.2.4.

### DIFF
--- a/src/core/utils_mac.mm
+++ b/src/core/utils_mac.mm
@@ -362,7 +362,7 @@ public Q_SLOTS:
         nswindow.movableByWindowBackground = NO;
         nswindow.movable = NO;
         // For some unknown reason, we don't need the following hack in some specific Qt versions.
-#if !(QT_VERSION >= QT_VERSION_CHECK(6, 0, 0) && QT_VERSION <= QT_VERSION_CHECK(6, 2, 4))
+#if QT_VERSION > QT_VERSION_CHECK(6, 2, 4)
         [nswindow standardWindowButton:NSWindowCloseButton].hidden = (visible ? NO : YES);
         [nswindow standardWindowButton:NSWindowMiniaturizeButton].hidden = (visible ? NO : YES);
         [nswindow standardWindowButton:NSWindowZoomButton].hidden = (visible ? NO : YES);


### PR DESCRIPTION
经验证，Qt 5.15.2也存在相关问题，故将版本条件修改为Qt 6.2.4以下。
解决此问题 #224 