### PR TITLE
fix setOverrideTheme render multiple times

### DIFF
--- a/src/core/framelessmanager.cpp
+++ b/src/core/framelessmanager.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * MIT License
  *
  * Copyright (C) 2021-2023 by wangwenx190 (Yuhang Zhao)
@@ -418,6 +418,9 @@ void FramelessManager::removeWindow(const WId windowId)
 void FramelessManager::setOverrideTheme(const SystemTheme theme)
 {
     Q_D(FramelessManager);
+    if(theme==systemTheme()){
+        return;
+    }
     d->setOverrideTheme(theme);
 }
 

--- a/src/core/framelessmanager.cpp
+++ b/src/core/framelessmanager.cpp
@@ -309,6 +309,9 @@ bool FramelessManagerPrivate::usePureQtImplementation()
 
 void FramelessManagerPrivate::setOverrideTheme(const SystemTheme theme)
 {
+    if(theme==systemTheme()){
+        return;
+    }
     if (theme == SystemTheme::Unknown) {
         m_overrideTheme = std::nullopt;
     } else {
@@ -418,9 +421,6 @@ void FramelessManager::removeWindow(const WId windowId)
 void FramelessManager::setOverrideTheme(const SystemTheme theme)
 {
     Q_D(FramelessManager);
-    if(theme==systemTheme()){
-        return;
-    }
     d->setOverrideTheme(theme);
 }
 

--- a/src/core/framelessmanager.cpp
+++ b/src/core/framelessmanager.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * MIT License
  *
  * Copyright (C) 2021-2023 by wangwenx190 (Yuhang Zhao)

--- a/src/quick/framelessquickutils.cpp
+++ b/src/quick/framelessquickutils.cpp
@@ -89,9 +89,6 @@ QuickGlobal::SystemTheme FramelessQuickUtils::systemTheme() const
 
 void FramelessQuickUtils::setOverrideTheme(const QuickGlobal::SystemTheme theme)
 {
-    if(theme==systemTheme()){
-        return;
-    }
     FramelessManager::instance()->setOverrideTheme(FRAMELESSHELPER_ENUM_QUICK_TO_CORE(SystemTheme, theme));
 }
 

--- a/src/quick/framelessquickutils.cpp
+++ b/src/quick/framelessquickutils.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * MIT License
  *
  * Copyright (C) 2021-2023 by wangwenx190 (Yuhang Zhao)
@@ -89,6 +89,9 @@ QuickGlobal::SystemTheme FramelessQuickUtils::systemTheme() const
 
 void FramelessQuickUtils::setOverrideTheme(const QuickGlobal::SystemTheme theme)
 {
+    if(theme==systemTheme()){
+        return;
+    }
     FramelessManager::instance()->setOverrideTheme(FRAMELESSHELPER_ENUM_QUICK_TO_CORE(SystemTheme, theme));
 }
 

--- a/src/quick/framelessquickutils.cpp
+++ b/src/quick/framelessquickutils.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * MIT License
  *
  * Copyright (C) 2021-2023 by wangwenx190 (Yuhang Zhao)


### PR DESCRIPTION
![微信图片_20230521231229](https://github.com/wangwenx190/framelesshelper/assets/56627161/ae84f651-2932-4669-ac4a-6a48d8ab4dc0)
多次调用setOverrideTheme相同参数的时候会重复绘制，导致界面异常。。