### PR TITLE
Fix the bug of unregistered datatype QuickGlobal::SystemTheme in Qt 5.

### DIFF
--- a/src/quick/framelessquickmodule.cpp
+++ b/src/quick/framelessquickmodule.cpp
@@ -91,7 +91,13 @@ void FramelessHelper::Quick::registerTypes(QQmlEngine *engine)
             return new FramelessQuickUtils;
         });
     qmlRegisterAnonymousType<QuickChromePalette>(QUICK_URI_SHORT);
-
+#if (QT_VERSION <= QT_VERSION_CHECK(5, 16, 0))
+    qRegisterMetaType<QuickGlobal::SystemTheme>("QuickGlobal::SystemTheme");
+    qRegisterMetaType<QuickGlobal::SystemButtonType>("QuickGlobal::SystemButtonType");
+    qRegisterMetaType<QuickGlobal::ButtonState>("QuickGlobal::ButtonState");
+    qRegisterMetaType<QuickGlobal::BlurMode>("QuickGlobal::BlurMode");
+    qRegisterMetaType<QuickGlobal::WindowEdge>("QuickGlobal::WindowEdge");
+#endif
     qmlRegisterType<FramelessQuickHelper>(QUICK_URI_EXPAND("FramelessHelper"));
     qmlRegisterType<QuickMicaMaterial>(QUICK_URI_EXPAND("MicaMaterial"));
     qmlRegisterType<QuickImageItem>(QUICK_URI_EXPAND("ImageItem"));


### PR DESCRIPTION
修复Qt 5下使用Qt Quick，将`FramelessHelperConstants.Dark`等值赋值给类似`FramelessUtils.systemTheme`等对象时出现的如下问题：
![d8dd70f95057766d04efc7a561b06843](https://github.com/wangwenx190/framelesshelper/assets/30333935/1c4b9b61-d67c-433e-a3c7-37e5403af561)
